### PR TITLE
[RFR] Add inverse method to PCA

### DIFF
--- a/pca.d.ts
+++ b/pca.d.ts
@@ -22,6 +22,7 @@ declare module 'ml-pca' {
     constructor(dataset: number[][] | Matrix, options?: IPCAOptions);
     static load(model: IPCAModel): PCA;
     predict(dataset: number[][] | Matrix, options?: IPredictOptions): Matrix;
+    invert(dataset: number[][] | Matrix): Matrix;
     getExplainedVariance(): number[];
     getCumulativeVariance(): number[];
     getEigenvectors(): Matrix;

--- a/src/__tests__/iris.js
+++ b/src/__tests__/iris.js
@@ -52,14 +52,13 @@ describe('iris dataset', function () {
     );
   });
   it('inverting scaled', () => {
-    var dataset = [[1, 2, 3], [0, 3, 5], [2, 2, 2]];
     var input = iris.slice(0, 2);
     var pred = pca.predict(input);
 
     var mean = new Matrix(iris).mean('column');
     var inv = pca.invert(pred, mean);
 
-    expect(inv.to2DArray()).toBeDeepCloseTo(dataset);
+    expect(inv.to2DArray()).toBeDeepCloseTo(input);
   });
   it('inverting not scaled', () => {
     var dataset = [[1, 2, 3], [0, 3, 5], [2, 2, 2]];

--- a/src/__tests__/iris.js
+++ b/src/__tests__/iris.js
@@ -51,6 +51,26 @@ describe('iris dataset', function () {
       3
     );
   });
+  it('inverting scaled', () => {
+    var dataset = [[1, 2, 3], [0, 3, 5], [2, 2, 2]];
+    var input = iris.slice(0, 2);
+    var pred = pca.predict(input);
+
+    var mean = new Matrix(iris).mean('column');
+    var inv = pca.invert(pred, mean);
+
+    expect(inv.to2DArray()).toBeDeepCloseTo(dataset);
+  });
+  it('inverting not scaled', () => {
+    var dataset = [[1, 2, 3], [0, 3, 5], [2, 2, 2]];
+    var newpca = new PCA(dataset);
+    var pred = newpca.predict(dataset);
+
+    var mean = new Matrix(dataset).mean('column');
+    var inv = newpca.invert(pred, mean);
+
+    expect(inv.to2DArray()).toBeDeepCloseTo(dataset);
+  });
 });
 
 describe('iris dataset with provided covariance matrix', function () {

--- a/src/__tests__/iris.js
+++ b/src/__tests__/iris.js
@@ -55,8 +55,7 @@ describe('iris dataset', function () {
     var input = iris.slice(0, 2);
     var pred = pca.predict(input);
 
-    var mean = new Matrix(iris).mean('column');
-    var inv = pca.invert(pred, mean);
+    var inv = pca.invert(pred);
 
     expect(inv.to2DArray()).toBeDeepCloseTo(input);
   });
@@ -65,8 +64,7 @@ describe('iris dataset', function () {
     var newpca = new PCA(dataset);
     var pred = newpca.predict(dataset);
 
-    var mean = new Matrix(dataset).mean('column');
-    var inv = newpca.invert(pred, mean);
+    var inv = newpca.invert(pred);
 
     expect(inv.to2DArray()).toBeDeepCloseTo(dataset);
   });

--- a/src/__tests__/test.js
+++ b/src/__tests__/test.js
@@ -1,5 +1,3 @@
-import { Matrix } from 'ml-matrix';
-
 import { PCA } from '../pca';
 
 
@@ -127,19 +125,5 @@ describe('PCA algorithm', function () {
   it('should throw on load if wrong model', () => {
     expect(() => PCA.load({})).toThrow(/model must have a name property/);
     expect(() => PCA.load({ name: 'test' })).toThrow(/invalid model: test/);
-  });
-
-  it('should inverse pca should be equal to input', () => {
-    var dataset = [[2, 2, 0], [3, 4, 0], [5, 6, 0]];
-
-    var newpca = new PCA(dataset);
-    var pcaPrediction = newpca.predict([dataset[0]]);
-
-    var mean = new Matrix(dataset).mean('column');
-    var inv = newpca.invert(pcaPrediction, mean);
-
-    inv.data[0].forEach((v, key) => {
-      expect(v).toBeCloseTo(dataset[0][key]);
-    });
   });
 });

--- a/src/__tests__/test.js
+++ b/src/__tests__/test.js
@@ -1,4 +1,7 @@
+import { Matrix } from 'ml-matrix';
+
 import { PCA } from '../pca';
+
 
 describe('PCA algorithm', function () {
   var testDataset = [
@@ -124,5 +127,19 @@ describe('PCA algorithm', function () {
   it('should throw on load if wrong model', () => {
     expect(() => PCA.load({})).toThrow(/model must have a name property/);
     expect(() => PCA.load({ name: 'test' })).toThrow(/invalid model: test/);
+  });
+
+  it('should inverse pca should be equal to input', () => {
+    var dataset = [[2, 2, 0], [3, 4, 0], [5, 6, 0]];
+
+    var newpca = new PCA(dataset);
+    var pcaPrediction = newpca.predict([dataset[0]]);
+
+    var mean = new Matrix(dataset).mean('column');
+    var inv = newpca.invert(pcaPrediction, mean);
+
+    inv.data[0].forEach((v, key) => {
+      expect(v).toBeCloseTo(dataset[0][key]);
+    });
   });
 });

--- a/src/__tests__/test.js
+++ b/src/__tests__/test.js
@@ -1,6 +1,5 @@
 import { PCA } from '../pca';
 
-
 describe('PCA algorithm', function () {
   var testDataset = [
     [3.38156266663556, 3.38911268489207],

--- a/src/pca.js
+++ b/src/pca.js
@@ -113,10 +113,9 @@ export class PCA {
   /**
    * Calculates the inverse PCA transform
    * @param {Matrix} dataset
-   * @param {Array} mean
    * @return {Matrix} dataset projected in the PCA space
    */
-  invert(dataset, mean) {
+  invert(dataset) {
     dataset = Matrix.checkMatrix(dataset);
 
     var inverse = dataset.mmul(this.U.transpose());
@@ -125,7 +124,7 @@ export class PCA {
       if (this.scale) {
         inverse.mulRowVector(this.stdevs);
       }
-      inverse.addRowVector(mean);
+      inverse.addRowVector(this.means);
     }
 
     return inverse;

--- a/src/pca.js
+++ b/src/pca.js
@@ -117,12 +117,15 @@ export class PCA {
    * @return {Matrix} dataset projected in the PCA space
    */
   invert(dataset, mean) {
-    dataset = new Matrix(dataset);
+    dataset = Matrix.checkMatrix(dataset);
 
-    var meanPlaceholder = new Array(dataset.length).fill(0);
-    var meanMatrix = new Matrix(meanPlaceholder.map(() => mean));
+    var inverse = dataset.mmul(this.U.transpose()).addRowVector(mean);
 
-    return dataset.mmul(this.U.transpose()).add(meanMatrix);
+    if (this.scale) {
+      inverse.mulRowVector(this.stdevs);
+    }
+
+    return inverse;
   }
 
 

--- a/src/pca.js
+++ b/src/pca.js
@@ -119,10 +119,13 @@ export class PCA {
   invert(dataset, mean) {
     dataset = Matrix.checkMatrix(dataset);
 
-    var inverse = dataset.mmul(this.U.transpose()).addRowVector(mean);
+    var inverse = dataset.mmul(this.U.transpose());
 
-    if (this.scale) {
-      inverse.mulRowVector(this.stdevs);
+    if (this.center) {
+      if (this.scale) {
+        inverse.mulRowVector(this.stdevs);
+      }
+      inverse.addRowVector(mean);
     }
 
     return inverse;

--- a/src/pca.js
+++ b/src/pca.js
@@ -111,6 +111,22 @@ export class PCA {
   }
 
   /**
+   * Calculates the inverse PCA transform
+   * @param {Matrix} dataset
+   * @param {Array} mean
+   * @return {Matrix} dataset projected in the PCA space
+   */
+  invert(dataset, mean) {
+    dataset = new Matrix(dataset);
+
+    var meanPlaceholder = new Array(dataset.length).fill(0);
+    var meanMatrix = new Matrix(meanPlaceholder.map(() => mean));
+
+    return dataset.mmul(this.U.transpose()).add(meanMatrix);
+  }
+
+
+  /**
    * Returns the proportion of variance for each component
    * @return {[number]}
    */


### PR DESCRIPTION
Add an inverse method, so one can return to the first vector space.
This is usually available in other ml libraries like sklearn.